### PR TITLE
feat: implement POST /user with event sourcing flow

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -61,12 +61,12 @@ func main() {
 	eventHandler := usecaseevent.NewMainHandler(eventRepo, broker)
 	createUserUC := usecaseuser.NewCreateUserUseCase(eventHandler)
 
-	userBroker := apimessaging.NewUserBroker(broker, userRepo, pwdUtil)
+	userBroker := apimessaging.NewUserBroker(broker, userRepo)
 	if err := userBroker.Subscribe(); err != nil {
 		log.Fatalf("Error starting user subscriber: %v", err)
 	}
 
-	userHandler := routes.NewUserHandler(createUserUC)
+	userHandler := routes.NewUserHandler(createUserUC, pwdUtil)
 	if err := api.StartAPI(cfg, userHandler.SetupUserRouter); err != nil {
 		log.Fatalf("Error starting api: %v", err)
 	}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -4,26 +4,32 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"poc-event-source/config"
-	"poc-event-source/internal/api"
-	"poc-event-source/internal/api/routes"
-	"poc-event-source/internal/infrastructure"
 	"time"
 
 	"github.com/joho/godotenv"
+	"golang.org/x/crypto/bcrypt"
+	"poc-event-source/config"
+	"poc-event-source/internal/api"
+	apimessaging "poc-event-source/internal/api/messaging"
+	"poc-event-source/internal/api/routes"
+	usecaseevent "poc-event-source/internal/application/usecase/event"
+	usecaseuser "poc-event-source/internal/application/usecase/user"
+	"poc-event-source/internal/application/utils"
+	"poc-event-source/internal/infrastructure"
+	eventrepo "poc-event-source/internal/repository/event"
+	userrepo "poc-event-source/internal/repository/user"
 )
 
 func init() {
 	if err := godotenv.Load(".env"); err != nil {
-		log.Fatalf("erro ao carregar o arquivo .env: %v", err)
+		log.Fatalf("error loading .env file: %v", err)
 	}
 }
 
 func main() {
 	cfg := config.Load()
 
-	fmt.Println("Pass -> ", cfg.DatabasePassword)
-	_, err := infrastructure.NewGormDB(fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
+	eventsDB, err := infrastructure.NewGormDB(fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
 		cfg.DatabaseHost,
 		cfg.DatabasePort,
 		cfg.DatabaseUser,
@@ -34,19 +40,31 @@ func main() {
 		log.Fatalf("Error connecting to events db: %v", err)
 	}
 
-	_, err = infrastructure.NewGormDB(cfg.ProjectionDBURL)
+	projectionDB, err := infrastructure.NewGormDB(cfg.ProjectionDBURL)
 	if err != nil {
-		log.Printf("Error connecting to projection db: %v", err)
+		log.Fatalf("Error connecting to projection db: %v", err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 168*time.Hour)
-	_, err = infrastructure.Nats(cfg.BrokerURL, cfg.BrokerStreamName, cfg.BrokerSubjects, ctx, cancel)
+	broker, err := infrastructure.Nats(cfg.BrokerURL, cfg.BrokerStreamName, cfg.BrokerSubjects, ctx, cancel)
 	if err != nil {
 		log.Fatalf("Error connecting to events broker: %v", err)
 	}
 
-	err = api.StartAPI(cfg, routes.SetupUserRouter)
-	if err != nil {
+	eventRepo := eventrepo.NewEventRepository(eventsDB)
+	userRepo := userrepo.NewUserRepository(projectionDB)
+	pwdUtil := utils.NewPasswordUtils(bcrypt.DefaultCost)
+
+	eventHandler := usecaseevent.NewMainHandler(eventRepo, broker)
+	createUserUC := usecaseuser.NewCreateUserUseCase(eventHandler)
+
+	userBroker := apimessaging.NewUserBroker(broker, userRepo, pwdUtil)
+	if err := userBroker.Subscribe(); err != nil {
+		log.Fatalf("Error starting user subscriber: %v", err)
+	}
+
+	userHandler := routes.NewUserHandler(createUserUC)
+	if err := api.StartAPI(cfg, userHandler.SetupUserRouter); err != nil {
 		log.Fatalf("Error starting api: %v", err)
 	}
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"time"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/joho/godotenv"
 	"golang.org/x/crypto/bcrypt"
@@ -22,7 +24,7 @@ import (
 
 func init() {
 	if err := godotenv.Load(".env"); err != nil {
-		log.Fatalf("error loading .env file: %v", err)
+		log.Printf("warning: .env file not found: %v", err)
 	}
 }
 
@@ -45,7 +47,8 @@ func main() {
 		log.Fatalf("Error connecting to projection db: %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 168*time.Hour)
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
 	broker, err := infrastructure.Nats(cfg.BrokerURL, cfg.BrokerStreamName, cfg.BrokerSubjects, ctx, cancel)
 	if err != nil {
 		log.Fatalf("Error connecting to events broker: %v", err)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -2,12 +2,21 @@ package api
 
 import (
 	"fmt"
+
 	"github.com/gin-gonic/gin"
+	ginbinding "github.com/gin-gonic/gin/binding"
+	"github.com/go-playground/validator/v10"
 	"poc-event-source/config"
 )
 
 func StartAPI(cfg config.Config, setupRouterFunc func(engine *gin.RouterGroup)) error {
 	r := gin.Default()
+
+	if v, ok := ginbinding.Validator.Engine().(*validator.Validate); ok {
+		v.RegisterValidation("pwd_bytes_max72", func(fl validator.FieldLevel) bool {
+			return len([]byte(fl.Field().String())) <= 72
+		})
+	}
 
 	apiGroup := r.Group("api/v1")
 	setupRouterFunc(apiGroup)

--- a/internal/api/messaging/new.go
+++ b/internal/api/messaging/new.go
@@ -12,19 +12,16 @@ import (
 type UserBroker struct {
 	broker   application.Broker
 	userRepo irepository.UserRepository
-	pwdUtil  application.PasswordUtil
 	handlers map[string]func(context.Context, *application.Message)
 }
 
 func NewUserBroker(
 	broker application.Broker,
 	userRepo irepository.UserRepository,
-	pwdUtil application.PasswordUtil,
 ) api.Subscriber {
 	ub := &UserBroker{
 		broker:   broker,
 		userRepo: userRepo,
-		pwdUtil:  pwdUtil,
 	}
 	ub.handlers = map[string]func(context.Context, *application.Message){
 		string(domain.CreateUser): ub.handleCreate,

--- a/internal/api/messaging/new.go
+++ b/internal/api/messaging/new.go
@@ -1,14 +1,34 @@
 package messaging
 
 import (
+	"context"
+
 	"poc-event-source/internal/api"
 	"poc-event-source/internal/application"
+	"poc-event-source/internal/application/irepository"
+	"poc-event-source/internal/domain"
 )
 
 type UserBroker struct {
-	broker application.Broker
+	broker   application.Broker
+	userRepo irepository.UserRepository
+	pwdUtil  application.PasswordUtil
+	handlers map[string]func(context.Context, *application.Message)
 }
 
-func NewUserBroker(broker application.Broker) api.Subscriber {
-	return &UserBroker{broker: broker}
+func NewUserBroker(
+	broker application.Broker,
+	userRepo irepository.UserRepository,
+	pwdUtil application.PasswordUtil,
+) api.Subscriber {
+	ub := &UserBroker{
+		broker:   broker,
+		userRepo: userRepo,
+		pwdUtil:  pwdUtil,
+	}
+	ub.handlers = map[string]func(context.Context, *application.Message){
+		string(domain.CreateUser): ub.handleCreate,
+		// string(domain.DeleteUser): ub.handleDelete,
+	}
+	return ub
 }

--- a/internal/api/messaging/user.go
+++ b/internal/api/messaging/user.go
@@ -56,6 +56,7 @@ func (ub *UserBroker) handleCreate(ctx context.Context, msg *application.Message
 
 	if _, err = ub.userRepo.CreateUser(&model.User{Username: input.Username, Password: hashed}); err != nil {
 		log.Printf("handleCreate: error creating user: %v", err)
+		return
 	}
 
 	msg.Ack()

--- a/internal/api/messaging/user.go
+++ b/internal/api/messaging/user.go
@@ -2,14 +2,61 @@ package messaging
 
 import (
 	"context"
-	"fmt"
+	"encoding/json"
+	"log"
+
 	"poc-event-source/internal/application"
+	"poc-event-source/internal/application/dto"
+	"poc-event-source/internal/infrastructure/model"
 )
 
 func (ub *UserBroker) Subscribe() error {
 	ctx := context.Background()
-	ub.broker.Subscribe(ctx, "user", func(ctx context.Context, msg *application.Message) {
-		fmt.Println(msg)
+	_, err := ub.broker.Subscribe(ctx, "user", func(ctx context.Context, msg *application.Message) {
+		var envelope dto.EventMessage
+		if err := json.Unmarshal(msg.Data, &envelope); err != nil {
+			log.Printf("Subscribe: error unmarshaling message: %v", err)
+			msg.Ack()
+			return
+		}
+
+		handler, ok := ub.handlers[envelope.Type]
+		if !ok {
+			log.Printf("Subscribe: no handler for event type: %s", envelope.Type)
+			msg.Ack()
+			return
+		}
+
+		handler(ctx, msg)
 	})
-	return nil
+	return err
+}
+
+func (ub *UserBroker) handleCreate(ctx context.Context, msg *application.Message) {
+	var envelope dto.EventMessage
+	if err := json.Unmarshal(msg.Data, &envelope); err != nil {
+		log.Printf("handleCreate: error unmarshaling envelope: %v", err)
+		msg.Ack()
+		return
+	}
+
+	var input dto.CreateUserReqDTO
+	if err := json.Unmarshal(envelope.Payload, &input); err != nil {
+		log.Printf("handleCreate: error unmarshaling payload: %v", err)
+		msg.Ack()
+		return
+	}
+
+	hashed, err := ub.pwdUtil.HashPassword(input.Password)
+	if err != nil {
+		log.Printf("handleCreate: error hashing password: %v", err)
+		msg.Ack()
+		return
+	}
+
+	if _, err = ub.userRepo.CreateUser(&model.User{Username: input.Username, Password: hashed}); err != nil {
+		log.Printf("handleCreate: error creating user: %v", err)
+	}
+
+	msg.Ack()
 }

--- a/internal/api/messaging/user.go
+++ b/internal/api/messaging/user.go
@@ -55,16 +55,7 @@ func (ub *UserBroker) handleCreate(ctx context.Context, msg *application.Message
 		return
 	}
 
-	hashed, err := ub.pwdUtil.HashPassword(input.Password)
-	if err != nil {
-		log.Printf("handleCreate: error hashing password: %v", err)
-		if err := msg.Ack(); err != nil {
-			log.Printf("handleCreate: ack failed: %v", err)
-		}
-		return
-	}
-
-	if _, err = ub.userRepo.CreateUser(&model.User{Username: input.Username, Password: hashed}); err != nil {
+	if _, err := ub.userRepo.CreateUser(&model.User{Username: input.Username, Password: input.Password}); err != nil {
 		log.Printf("handleCreate: error creating user: %v", err)
 		return
 	}

--- a/internal/api/messaging/user.go
+++ b/internal/api/messaging/user.go
@@ -16,14 +16,18 @@ func (ub *UserBroker) Subscribe() error {
 		var envelope dto.EventMessage
 		if err := json.Unmarshal(msg.Data, &envelope); err != nil {
 			log.Printf("Subscribe: error unmarshaling message: %v", err)
-			msg.Ack()
+			if err := msg.Ack(); err != nil {
+				log.Printf("Subscribe: ack failed: %v", err)
+			}
 			return
 		}
 
 		handler, ok := ub.handlers[envelope.Type]
 		if !ok {
 			log.Printf("Subscribe: no handler for event type: %s", envelope.Type)
-			msg.Ack()
+			if err := msg.Ack(); err != nil {
+				log.Printf("Subscribe: ack failed: %v", err)
+			}
 			return
 		}
 
@@ -36,21 +40,27 @@ func (ub *UserBroker) handleCreate(ctx context.Context, msg *application.Message
 	var envelope dto.EventMessage
 	if err := json.Unmarshal(msg.Data, &envelope); err != nil {
 		log.Printf("handleCreate: error unmarshaling envelope: %v", err)
-		msg.Ack()
+		if err := msg.Ack(); err != nil {
+			log.Printf("handleCreate: ack failed: %v", err)
+		}
 		return
 	}
 
 	var input dto.CreateUserReqDTO
 	if err := json.Unmarshal(envelope.Payload, &input); err != nil {
 		log.Printf("handleCreate: error unmarshaling payload: %v", err)
-		msg.Ack()
+		if err := msg.Ack(); err != nil {
+			log.Printf("handleCreate: ack failed: %v", err)
+		}
 		return
 	}
 
 	hashed, err := ub.pwdUtil.HashPassword(input.Password)
 	if err != nil {
 		log.Printf("handleCreate: error hashing password: %v", err)
-		msg.Ack()
+		if err := msg.Ack(); err != nil {
+			log.Printf("handleCreate: ack failed: %v", err)
+		}
 		return
 	}
 
@@ -59,5 +69,7 @@ func (ub *UserBroker) handleCreate(ctx context.Context, msg *application.Message
 		return
 	}
 
-	msg.Ack()
+	if err := msg.Ack(); err != nil {
+		log.Printf("handleCreate: ack failed: %v", err)
+	}
 }

--- a/internal/api/messaging/user_test.go
+++ b/internal/api/messaging/user_test.go
@@ -44,14 +44,6 @@ func (m *mockUserRepo) CreateUser(u *model.User) (*model.User, error) {
 	return m.createFn(u)
 }
 
-type mockPwdUtil struct {
-	hashFn func(password string) (string, error)
-}
-
-func (m *mockPwdUtil) HashPassword(password string) (string, error) {
-	return m.hashFn(password)
-}
-
 // --- helpers ---
 
 func buildMessage(t *testing.T, eventType string, payload interface{}) (*application.Message, *bool) {
@@ -79,28 +71,20 @@ func TestUserBroker_Subscribe_handleCreate(t *testing.T) {
 		name       string
 		eventType  string
 		payload    dto.CreateUserReqDTO
-		hashErr    error
 		wantCreate bool
 		wantAck    bool
 	}{
 		{
 			name:       "creates user successfully",
 			eventType:  string(domain.CreateUser),
-			payload:    dto.CreateUserReqDTO{Username: "alice", Password: "secret"},
+			payload:    dto.CreateUserReqDTO{Username: "alice", Password: "$2a$10$hashedpwd"},
 			wantCreate: true,
 			wantAck:    true,
 		},
 		{
 			name:      "unknown event type — ack only, no user created",
 			eventType: "UNKNOWN_EVENT",
-			payload:   dto.CreateUserReqDTO{Username: "alice", Password: "secret"},
-			wantAck:   true,
-		},
-		{
-			name:      "hash error — user not created",
-			eventType: string(domain.CreateUser),
-			payload:   dto.CreateUserReqDTO{Username: "alice", Password: "secret"},
-			hashErr:   errors.New("hash error"),
+			payload:   dto.CreateUserReqDTO{Username: "alice", Password: "$2a$10$hashedpwd"},
 			wantAck:   true,
 		},
 	}
@@ -117,23 +101,13 @@ func TestUserBroker_Subscribe_handleCreate(t *testing.T) {
 					created = true
 					if tt.wantCreate {
 						assert.Equal(t, tt.payload.Username, u.Username)
-						assert.Equal(t, "hashed", u.Password)
+						assert.Equal(t, tt.payload.Password, u.Password)
 					}
 					return u, nil
 				},
 			}
 
-			hashErr := tt.hashErr
-			pwdUtil := &mockPwdUtil{
-				hashFn: func(_ string) (string, error) {
-					if hashErr != nil {
-						return "", hashErr
-					}
-					return "hashed", nil
-				},
-			}
-
-			userBroker := messaging.NewUserBroker(broker, repo, pwdUtil)
+			userBroker := messaging.NewUserBroker(broker, repo)
 			err := userBroker.Subscribe()
 
 			assert.NoError(t, err)
@@ -144,7 +118,7 @@ func TestUserBroker_Subscribe_handleCreate(t *testing.T) {
 }
 
 func TestUserBroker_Subscribe_handleCreate_dbError_noAck(t *testing.T) {
-	msg, acked := buildMessage(t, string(domain.CreateUser), dto.CreateUserReqDTO{Username: "alice", Password: "secret"})
+	msg, acked := buildMessage(t, string(domain.CreateUser), dto.CreateUserReqDTO{Username: "alice", Password: "$2a$10$hashedpwd"})
 
 	broker := &syncBroker{msg: msg}
 	repo := &mockUserRepo{
@@ -152,9 +126,8 @@ func TestUserBroker_Subscribe_handleCreate_dbError_noAck(t *testing.T) {
 			return nil, errors.New("db error")
 		},
 	}
-	pwdUtil := &mockPwdUtil{hashFn: func(_ string) (string, error) { return "hashed", nil }}
 
-	userBroker := messaging.NewUserBroker(broker, repo, pwdUtil)
+	userBroker := messaging.NewUserBroker(broker, repo)
 	err := userBroker.Subscribe()
 
 	assert.NoError(t, err)
@@ -176,9 +149,8 @@ func TestUserBroker_Subscribe_invalidJSON(t *testing.T) {
 			return nil, nil
 		},
 	}
-	pwdUtil := &mockPwdUtil{hashFn: func(_ string) (string, error) { return "h", nil }}
 
-	userBroker := messaging.NewUserBroker(broker, repo, pwdUtil)
+	userBroker := messaging.NewUserBroker(broker, repo)
 	err := userBroker.Subscribe()
 
 	assert.NoError(t, err)

--- a/internal/api/messaging/user_test.go
+++ b/internal/api/messaging/user_test.go
@@ -1,0 +1,162 @@
+package messaging_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"poc-event-source/internal/api/messaging"
+	"poc-event-source/internal/application"
+	"poc-event-source/internal/application/dto"
+	"poc-event-source/internal/domain"
+	"poc-event-source/internal/infrastructure/model"
+)
+
+// --- mocks ---
+
+type mockSubscription struct{}
+
+func (m *mockSubscription) Unsubscribe() error { return nil }
+
+// syncBroker invokes the handler synchronously when Subscribe is called, simplifying tests
+type syncBroker struct {
+	msg *application.Message
+}
+
+func (b *syncBroker) Subscribe(_ context.Context, _ string, handler func(context.Context, *application.Message)) (application.Subscription, error) {
+	handler(context.Background(), b.msg)
+	return &mockSubscription{}, nil
+}
+func (b *syncBroker) Publish(_ context.Context, _ string, _ []byte) error { return nil }
+func (b *syncBroker) QueueSubscribe(_ context.Context, _, _ string, _ func(context.Context, *application.Message)) (application.Subscription, error) {
+	return nil, nil
+}
+func (b *syncBroker) Close() error { return nil }
+
+type mockUserRepo struct {
+	createFn func(u *model.User) (*model.User, error)
+}
+
+func (m *mockUserRepo) CreateUser(u *model.User) (*model.User, error) {
+	return m.createFn(u)
+}
+
+type mockPwdUtil struct {
+	hashFn func(password string) (string, error)
+}
+
+func (m *mockPwdUtil) HashPassword(password string) (string, error) {
+	return m.hashFn(password)
+}
+
+// --- helpers ---
+
+func buildMessage(eventType string, payload interface{}) (*application.Message, *bool) {
+	payloadBytes, _ := json.Marshal(payload)
+	envelope, _ := json.Marshal(dto.EventMessage{
+		Type:    eventType,
+		Payload: payloadBytes,
+	})
+	acked := false
+	msg := &application.Message{
+		Topic: "user",
+		Data:  envelope,
+		Ack:   func() error { acked = true; return nil },
+	}
+	return msg, &acked
+}
+
+// --- tests ---
+
+func TestUserBroker_Subscribe_handleCreate(t *testing.T) {
+	tests := []struct {
+		name       string
+		eventType  string
+		payload    dto.CreateUserReqDTO
+		hashErr    error
+		wantCreate bool
+	}{
+		{
+			name:       "creates user successfully",
+			eventType:  string(domain.CreateUser),
+			payload:    dto.CreateUserReqDTO{Username: "alice", Password: "secret"},
+			wantCreate: true,
+		},
+		{
+			name:       "unknown event type — ack only, no user created",
+			eventType:  "UNKNOWN_EVENT",
+			payload:    dto.CreateUserReqDTO{Username: "alice", Password: "secret"},
+			wantCreate: false,
+		},
+		{
+			name:       "hash error — user not created",
+			eventType:  string(domain.CreateUser),
+			payload:    dto.CreateUserReqDTO{Username: "alice", Password: "secret"},
+			hashErr:    errors.New("hash error"),
+			wantCreate: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			created := false
+			msg, acked := buildMessage(tt.eventType, tt.payload)
+
+			broker := &syncBroker{msg: msg}
+
+			repo := &mockUserRepo{
+				createFn: func(u *model.User) (*model.User, error) {
+					created = true
+					if tt.wantCreate {
+						assert.Equal(t, tt.payload.Username, u.Username)
+						assert.Equal(t, "hashed", u.Password)
+					}
+					return u, nil
+				},
+			}
+
+			hashErr := tt.hashErr
+			pwdUtil := &mockPwdUtil{
+				hashFn: func(_ string) (string, error) {
+					if hashErr != nil {
+						return "", hashErr
+					}
+					return "hashed", nil
+				},
+			}
+
+			userBroker := messaging.NewUserBroker(broker, repo, pwdUtil)
+			err := userBroker.Subscribe()
+
+			assert.NoError(t, err)
+			assert.True(t, *acked, "msg.Ack() must always be called")
+			assert.Equal(t, tt.wantCreate, created)
+		})
+	}
+}
+
+func TestUserBroker_Subscribe_invalidJSON(t *testing.T) {
+	acked := false
+	msg := &application.Message{
+		Topic: "user",
+		Data:  []byte("not-json"),
+		Ack:   func() error { acked = true; return nil },
+	}
+
+	broker := &syncBroker{msg: msg}
+	repo := &mockUserRepo{
+		createFn: func(_ *model.User) (*model.User, error) {
+			t.Fatal("CreateUser must not be called with invalid JSON")
+			return nil, nil
+		},
+	}
+	pwdUtil := &mockPwdUtil{hashFn: func(_ string) (string, error) { return "h", nil }}
+
+	userBroker := messaging.NewUserBroker(broker, repo, pwdUtil)
+	err := userBroker.Subscribe()
+
+	assert.NoError(t, err)
+	assert.True(t, acked, "msg.Ack() must be called even with invalid JSON")
+}

--- a/internal/api/messaging/user_test.go
+++ b/internal/api/messaging/user_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"poc-event-source/internal/api/messaging"
 	"poc-event-source/internal/application"
 	"poc-event-source/internal/application/dto"
@@ -25,8 +26,8 @@ type syncBroker struct {
 	msg *application.Message
 }
 
-func (b *syncBroker) Subscribe(_ context.Context, _ string, handler func(context.Context, *application.Message)) (application.Subscription, error) {
-	handler(context.Background(), b.msg)
+func (b *syncBroker) Subscribe(ctx context.Context, _ string, handler func(context.Context, *application.Message)) (application.Subscription, error) {
+	handler(ctx, b.msg)
 	return &mockSubscription{}, nil
 }
 func (b *syncBroker) Publish(_ context.Context, _ string, _ []byte) error { return nil }
@@ -53,12 +54,15 @@ func (m *mockPwdUtil) HashPassword(password string) (string, error) {
 
 // --- helpers ---
 
-func buildMessage(eventType string, payload interface{}) (*application.Message, *bool) {
-	payloadBytes, _ := json.Marshal(payload)
-	envelope, _ := json.Marshal(dto.EventMessage{
+func buildMessage(t *testing.T, eventType string, payload interface{}) (*application.Message, *bool) {
+	t.Helper()
+	payloadBytes, err := json.Marshal(payload)
+	require.NoError(t, err)
+	envelope, err := json.Marshal(dto.EventMessage{
 		Type:    eventType,
 		Payload: payloadBytes,
 	})
+	require.NoError(t, err)
 	acked := false
 	msg := &application.Message{
 		Topic: "user",
@@ -77,32 +81,34 @@ func TestUserBroker_Subscribe_handleCreate(t *testing.T) {
 		payload    dto.CreateUserReqDTO
 		hashErr    error
 		wantCreate bool
+		wantAck    bool
 	}{
 		{
 			name:       "creates user successfully",
 			eventType:  string(domain.CreateUser),
 			payload:    dto.CreateUserReqDTO{Username: "alice", Password: "secret"},
 			wantCreate: true,
+			wantAck:    true,
 		},
 		{
-			name:       "unknown event type — ack only, no user created",
-			eventType:  "UNKNOWN_EVENT",
-			payload:    dto.CreateUserReqDTO{Username: "alice", Password: "secret"},
-			wantCreate: false,
+			name:      "unknown event type — ack only, no user created",
+			eventType: "UNKNOWN_EVENT",
+			payload:   dto.CreateUserReqDTO{Username: "alice", Password: "secret"},
+			wantAck:   true,
 		},
 		{
-			name:       "hash error — user not created",
-			eventType:  string(domain.CreateUser),
-			payload:    dto.CreateUserReqDTO{Username: "alice", Password: "secret"},
-			hashErr:    errors.New("hash error"),
-			wantCreate: false,
+			name:      "hash error — user not created",
+			eventType: string(domain.CreateUser),
+			payload:   dto.CreateUserReqDTO{Username: "alice", Password: "secret"},
+			hashErr:   errors.New("hash error"),
+			wantAck:   true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			created := false
-			msg, acked := buildMessage(tt.eventType, tt.payload)
+			msg, acked := buildMessage(t, tt.eventType, tt.payload)
 
 			broker := &syncBroker{msg: msg}
 
@@ -131,10 +137,28 @@ func TestUserBroker_Subscribe_handleCreate(t *testing.T) {
 			err := userBroker.Subscribe()
 
 			assert.NoError(t, err)
-			assert.True(t, *acked, "msg.Ack() must always be called")
+			assert.Equal(t, tt.wantAck, *acked)
 			assert.Equal(t, tt.wantCreate, created)
 		})
 	}
+}
+
+func TestUserBroker_Subscribe_handleCreate_dbError_noAck(t *testing.T) {
+	msg, acked := buildMessage(t, string(domain.CreateUser), dto.CreateUserReqDTO{Username: "alice", Password: "secret"})
+
+	broker := &syncBroker{msg: msg}
+	repo := &mockUserRepo{
+		createFn: func(_ *model.User) (*model.User, error) {
+			return nil, errors.New("db error")
+		},
+	}
+	pwdUtil := &mockPwdUtil{hashFn: func(_ string) (string, error) { return "hashed", nil }}
+
+	userBroker := messaging.NewUserBroker(broker, repo, pwdUtil)
+	err := userBroker.Subscribe()
+
+	assert.NoError(t, err)
+	assert.False(t, *acked, "msg.Ack() must NOT be called when CreateUser fails")
 }
 
 func TestUserBroker_Subscribe_invalidJSON(t *testing.T) {

--- a/internal/api/routes/user.go
+++ b/internal/api/routes/user.go
@@ -1,23 +1,37 @@
 package routes
 
 import (
-	"fmt"
+	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"poc-event-source/internal/application/dto"
+	usecaseuser "poc-event-source/internal/application/usecase/user"
 )
 
-func SetupUserRouter(r *gin.RouterGroup) {
-	userGroup := r.Group("/user")
+type UserHandler struct {
+	createUser usecaseuser.CreateUserUseCase
+}
 
-	userGroup.POST("", func(context *gin.Context) {
-		fmt.Printf("Create User")
-	})
+func NewUserHandler(cu usecaseuser.CreateUserUseCase) *UserHandler {
+	return &UserHandler{createUser: cu}
+}
 
-	userGroup.GET("/:id", func(context *gin.Context) {
-		fmt.Printf("Get User By ID")
-	})
+func (h *UserHandler) SetupUserRouter(r *gin.RouterGroup) {
+	g := r.Group("/user")
+	g.POST("", h.create)
+	g.GET("/:id", func(c *gin.Context) { c.JSON(http.StatusNotImplemented, nil) })
+	g.PUT("/:id", func(c *gin.Context) { c.JSON(http.StatusNotImplemented, nil) })
+}
 
-	userGroup.PUT("/:id", func(context *gin.Context) {
-		fmt.Printf("Update User")
-	})
+func (h *UserHandler) create(c *gin.Context) {
+	var req dto.CreateUserReqDTO
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := h.createUser.Execute(c.Request.Context(), req); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"status": "event published"})
 }

--- a/internal/api/routes/user.go
+++ b/internal/api/routes/user.go
@@ -33,5 +33,5 @@ func (h *UserHandler) create(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(http.StatusCreated, gin.H{"status": "event published"})
+	c.JSON(http.StatusAccepted, gin.H{"status": "event published"})
 }

--- a/internal/api/routes/user.go
+++ b/internal/api/routes/user.go
@@ -5,16 +5,18 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"poc-event-source/internal/application"
 	"poc-event-source/internal/application/dto"
 	usecaseuser "poc-event-source/internal/application/usecase/user"
 )
 
 type UserHandler struct {
 	createUser usecaseuser.CreateUserUseCase
+	pwdUtil    application.PasswordUtil
 }
 
-func NewUserHandler(cu usecaseuser.CreateUserUseCase) *UserHandler {
-	return &UserHandler{createUser: cu}
+func NewUserHandler(cu usecaseuser.CreateUserUseCase, pwdUtil application.PasswordUtil) *UserHandler {
+	return &UserHandler{createUser: cu, pwdUtil: pwdUtil}
 }
 
 func (h *UserHandler) SetupUserRouter(r *gin.RouterGroup) {
@@ -30,6 +32,13 @@ func (h *UserHandler) create(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+	hashed, err := h.pwdUtil.HashPassword(req.Password)
+	if err != nil {
+		log.Printf("create user: hash password: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create user"})
+		return
+	}
+	req.Password = hashed
 	if err := h.createUser.Execute(c.Request.Context(), req); err != nil {
 		log.Printf("create user: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create user"})

--- a/internal/api/routes/user.go
+++ b/internal/api/routes/user.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -30,7 +31,8 @@ func (h *UserHandler) create(c *gin.Context) {
 		return
 	}
 	if err := h.createUser.Execute(c.Request.Context(), req); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		log.Printf("create user: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create user"})
 		return
 	}
 	c.JSON(http.StatusAccepted, gin.H{"status": "event published"})

--- a/internal/application/dto/user.go
+++ b/internal/application/dto/user.go
@@ -4,7 +4,7 @@ import "encoding/json"
 
 type CreateUserReqDTO struct {
 	Username string `json:"username" binding:"required"`
-	Password string `json:"password" binding:"required"`
+	Password string `json:"password" binding:"required,pwd_bytes_max72"`
 }
 
 type EventMessage struct {

--- a/internal/application/dto/user.go
+++ b/internal/application/dto/user.go
@@ -1,0 +1,13 @@
+package dto
+
+import "encoding/json"
+
+type CreateUserReqDTO struct {
+	Username string `json:"username" binding:"required"`
+	Password string `json:"password" binding:"required"`
+}
+
+type EventMessage struct {
+	Type    string          `json:"type"`
+	Payload json.RawMessage `json:"payload"`
+}

--- a/internal/application/irepository/event.go
+++ b/internal/application/irepository/event.go
@@ -1,9 +1,13 @@
 package irepository
 
-import "poc-event-source/internal/domain"
+import (
+	"context"
+
+	"poc-event-source/internal/domain"
+)
 
 type CreateEventRepository interface {
-	CreateEvent(event *domain.EventSource) (*domain.EventSource, error)
+	CreateEvent(ctx context.Context, event *domain.EventSource) (*domain.EventSource, error)
 }
 
 type EventRepository interface {

--- a/internal/application/irepository/event.go
+++ b/internal/application/irepository/event.go
@@ -1,9 +1,9 @@
 package irepository
 
-import "poc-event-source/internal/infrastructure/model"
+import "poc-event-source/internal/domain"
 
 type CreateEventRepository interface {
-	CreateEvent(event *model.EventSource) (*model.EventSource, error)
+	CreateEvent(event *domain.EventSource) (*domain.EventSource, error)
 }
 
 type EventRepository interface {

--- a/internal/application/usecase/event/handle.go
+++ b/internal/application/usecase/event/handle.go
@@ -5,11 +5,11 @@ import (
 	"encoding/json"
 
 	"poc-event-source/internal/application/dto"
-	"poc-event-source/internal/infrastructure/model"
+	"poc-event-source/internal/domain"
 )
 
 func (m *mainHandlerUseCase) Handler(ctx context.Context, topic string, event dto.EventReqDTO) error {
-	_, err := m.createEventRepo.CreateEvent(&model.EventSource{
+	_, err := m.createEventRepo.CreateEvent(&domain.EventSource{
 		Type:    event.Type,
 		Payload: event.Payload,
 	})

--- a/internal/application/usecase/event/handle.go
+++ b/internal/application/usecase/event/handle.go
@@ -1,20 +1,29 @@
 package event
 
 import (
+	"context"
+	"encoding/json"
+
 	"poc-event-source/internal/application/dto"
 	"poc-event-source/internal/infrastructure/model"
 )
 
-func (m *mainHandlerUseCase) Handler(event dto.EventReqDTO) error {
-	modelEv := &model.EventSource{
-		Payload: event.Payload,
+func (m *mainHandlerUseCase) Handler(ctx context.Context, topic string, event dto.EventReqDTO) error {
+	_, err := m.createEventRepo.CreateEvent(&model.EventSource{
 		Type:    event.Type,
-	}
-
-	_, err := m.createEventRepo.CreateEvent(modelEv)
+		Payload: event.Payload,
+	})
 	if err != nil {
 		return err
 	}
 
-	return nil
+	envelope, err := json.Marshal(dto.EventMessage{
+		Type:    event.Type,
+		Payload: json.RawMessage(event.Payload),
+	})
+	if err != nil {
+		return err
+	}
+
+	return m.broker.Publish(ctx, topic, envelope)
 }

--- a/internal/application/usecase/event/handle.go
+++ b/internal/application/usecase/event/handle.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (m *mainHandlerUseCase) Handler(ctx context.Context, topic string, event dto.EventReqDTO) error {
-	_, err := m.createEventRepo.CreateEvent(&domain.EventSource{
+	_, err := m.createEventRepo.CreateEvent(ctx, &domain.EventSource{
 		Type:    event.Type,
 		Payload: event.Payload,
 	})

--- a/internal/application/usecase/event/handle_test.go
+++ b/internal/application/usecase/event/handle_test.go
@@ -1,0 +1,106 @@
+package event_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gorm.io/datatypes"
+	"poc-event-source/internal/application"
+	"poc-event-source/internal/application/dto"
+	"poc-event-source/internal/application/usecase/event"
+	"poc-event-source/internal/domain"
+	"poc-event-source/internal/infrastructure/model"
+)
+
+// --- mocks ---
+
+type mockEventRepo struct {
+	createFn func(e *model.EventSource) (*model.EventSource, error)
+}
+
+func (m *mockEventRepo) CreateEvent(e *model.EventSource) (*model.EventSource, error) {
+	return m.createFn(e)
+}
+
+type mockBroker struct {
+	publishFn func(ctx context.Context, topic string, data []byte) error
+}
+
+func (m *mockBroker) Publish(ctx context.Context, topic string, data []byte) error {
+	return m.publishFn(ctx, topic, data)
+}
+func (m *mockBroker) Subscribe(_ context.Context, _ string, _ func(context.Context, *application.Message)) (application.Subscription, error) {
+	return nil, nil
+}
+func (m *mockBroker) QueueSubscribe(_ context.Context, _, _ string, _ func(context.Context, *application.Message)) (application.Subscription, error) {
+	return nil, nil
+}
+func (m *mockBroker) Close() error { return nil }
+
+// --- tests ---
+
+func TestMainHandlerUseCase_Handler(t *testing.T) {
+	ctx := context.Background()
+	validEvent := dto.EventReqDTO{
+		Type:    string(domain.CreateUser),
+		Payload: datatypes.JSON(`{"username":"alice","password":"secret"}`),
+	}
+
+	tests := []struct {
+		name      string
+		repoErr   error
+		brokerErr error
+		wantErr   bool
+	}{
+		{
+			name:    "saves event and publishes to broker successfully",
+			wantErr: false,
+		},
+		{
+			name:    "repo error does not publish to broker",
+			repoErr: errors.New("db error"),
+			wantErr: true,
+		},
+		{
+			name:      "broker error returns error",
+			brokerErr: errors.New("nats error"),
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			publishCalled := false
+
+			repo := &mockEventRepo{
+				createFn: func(e *model.EventSource) (*model.EventSource, error) {
+					return e, tt.repoErr
+				},
+			}
+			broker := &mockBroker{
+				publishFn: func(_ context.Context, topic string, data []byte) error {
+					publishCalled = true
+					assert.Equal(t, "user", topic)
+					assert.NotEmpty(t, data)
+					return tt.brokerErr
+				},
+			}
+
+			handler := event.NewMainHandler(repo, broker)
+			err := handler.Handler(ctx, "user", validEvent)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.True(t, publishCalled, "broker.Publish must be called on happy path")
+			}
+
+			if tt.repoErr != nil {
+				assert.False(t, publishCalled, "broker.Publish must not be called when repo fails")
+			}
+		})
+	}
+}

--- a/internal/application/usecase/event/handle_test.go
+++ b/internal/application/usecase/event/handle_test.go
@@ -11,16 +11,15 @@ import (
 	"poc-event-source/internal/application/dto"
 	"poc-event-source/internal/application/usecase/event"
 	"poc-event-source/internal/domain"
-	"poc-event-source/internal/infrastructure/model"
 )
 
 // --- mocks ---
 
 type mockEventRepo struct {
-	createFn func(e *model.EventSource) (*model.EventSource, error)
+	createFn func(e *domain.EventSource) (*domain.EventSource, error)
 }
 
-func (m *mockEventRepo) CreateEvent(e *model.EventSource) (*model.EventSource, error) {
+func (m *mockEventRepo) CreateEvent(e *domain.EventSource) (*domain.EventSource, error) {
 	return m.createFn(e)
 }
 
@@ -75,7 +74,7 @@ func TestMainHandlerUseCase_Handler(t *testing.T) {
 			publishCalled := false
 
 			repo := &mockEventRepo{
-				createFn: func(e *model.EventSource) (*model.EventSource, error) {
+				createFn: func(e *domain.EventSource) (*domain.EventSource, error) {
 					return e, tt.repoErr
 				},
 			}

--- a/internal/application/usecase/event/handle_test.go
+++ b/internal/application/usecase/event/handle_test.go
@@ -16,11 +16,11 @@ import (
 // --- mocks ---
 
 type mockEventRepo struct {
-	createFn func(e *domain.EventSource) (*domain.EventSource, error)
+	createFn func(ctx context.Context, e *domain.EventSource) (*domain.EventSource, error)
 }
 
-func (m *mockEventRepo) CreateEvent(e *domain.EventSource) (*domain.EventSource, error) {
-	return m.createFn(e)
+func (m *mockEventRepo) CreateEvent(ctx context.Context, e *domain.EventSource) (*domain.EventSource, error) {
+	return m.createFn(ctx, e)
 }
 
 type mockBroker struct {
@@ -74,7 +74,7 @@ func TestMainHandlerUseCase_Handler(t *testing.T) {
 			publishCalled := false
 
 			repo := &mockEventRepo{
-				createFn: func(e *domain.EventSource) (*domain.EventSource, error) {
+				createFn: func(_ context.Context, e *domain.EventSource) (*domain.EventSource, error) {
 					return e, tt.repoErr
 				},
 			}

--- a/internal/application/usecase/event/new.go
+++ b/internal/application/usecase/event/new.go
@@ -1,19 +1,25 @@
 package event
 
 import (
+	"context"
+
+	"poc-event-source/internal/application"
 	"poc-event-source/internal/application/dto"
 	"poc-event-source/internal/application/irepository"
 )
 
 type MainHandlerUseCase interface {
-	Handler(event dto.EventReqDTO) error
-}
-type mainHandlerUseCase struct {
-	createEventRepo irepository.CreateEventRepository
+	Handler(ctx context.Context, topic string, event dto.EventReqDTO) error
 }
 
-func NewMainHandler(createEventRepo irepository.CreateEventRepository) MainHandlerUseCase {
+type mainHandlerUseCase struct {
+	createEventRepo irepository.CreateEventRepository
+	broker          application.Broker
+}
+
+func NewMainHandler(createEventRepo irepository.CreateEventRepository, broker application.Broker) MainHandlerUseCase {
 	return &mainHandlerUseCase{
 		createEventRepo: createEventRepo,
+		broker:          broker,
 	}
 }

--- a/internal/application/usecase/user/create.go
+++ b/internal/application/usecase/user/create.go
@@ -1,0 +1,22 @@
+package user
+
+import (
+	"context"
+	"encoding/json"
+
+	"gorm.io/datatypes"
+	"poc-event-source/internal/application/dto"
+	"poc-event-source/internal/domain"
+)
+
+func (u *createUserUseCase) Execute(ctx context.Context, input dto.CreateUserReqDTO) error {
+	payloadBytes, err := json.Marshal(input)
+	if err != nil {
+		return err
+	}
+
+	return u.eventHandler.Handler(ctx, "user", dto.EventReqDTO{
+		Type:    string(domain.CreateUser),
+		Payload: datatypes.JSON(payloadBytes),
+	})
+}

--- a/internal/application/usecase/user/create_test.go
+++ b/internal/application/usecase/user/create_test.go
@@ -1,0 +1,74 @@
+package user_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"poc-event-source/internal/application/dto"
+	"poc-event-source/internal/application/usecase/user"
+	"poc-event-source/internal/domain"
+)
+
+// --- mock ---
+
+type mockEventHandler struct {
+	receivedTopic string
+	receivedEvent dto.EventReqDTO
+	returnErr     error
+}
+
+func (m *mockEventHandler) Handler(_ context.Context, topic string, event dto.EventReqDTO) error {
+	m.receivedTopic = topic
+	m.receivedEvent = event
+	return m.returnErr
+}
+
+// --- tests ---
+
+func TestCreateUserUseCase_Execute(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		input      dto.CreateUserReqDTO
+		handlerErr error
+		wantErr    bool
+		wantTopic  string
+		wantType   string
+	}{
+		{
+			name:      "delegates to eventHandler with correct topic and type",
+			input:     dto.CreateUserReqDTO{Username: "alice", Password: "secret"},
+			wantTopic: "user",
+			wantType:  string(domain.CreateUser),
+			wantErr:   false,
+		},
+		{
+			name:       "propagates eventHandler error",
+			input:      dto.CreateUserReqDTO{Username: "alice", Password: "secret"},
+			handlerErr: errors.New("handler error"),
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockEventHandler{returnErr: tt.handlerErr}
+			uc := user.NewCreateUserUseCase(mock)
+
+			err := uc.Execute(ctx, tt.input)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantTopic, mock.receivedTopic)
+			assert.Equal(t, tt.wantType, mock.receivedEvent.Type)
+			assert.Contains(t, string(mock.receivedEvent.Payload), tt.input.Username)
+		})
+	}
+}

--- a/internal/application/usecase/user/new.go
+++ b/internal/application/usecase/user/new.go
@@ -1,0 +1,20 @@
+package user
+
+import (
+	"context"
+
+	"poc-event-source/internal/application/dto"
+	eventhandler "poc-event-source/internal/application/usecase/event"
+)
+
+type CreateUserUseCase interface {
+	Execute(ctx context.Context, input dto.CreateUserReqDTO) error
+}
+
+type createUserUseCase struct {
+	eventHandler eventhandler.MainHandlerUseCase
+}
+
+func NewCreateUserUseCase(eventHandler eventhandler.MainHandlerUseCase) CreateUserUseCase {
+	return &createUserUseCase{eventHandler: eventHandler}
+}

--- a/internal/application/utils/password_test.go
+++ b/internal/application/utils/password_test.go
@@ -20,40 +20,40 @@ func TestHashPassword(t *testing.T) {
 		assertFunc func(t *testing.T, hash string, err error)
 	}{
 		{
-			name:     "senha válida deve gerar hash sem erros",
-			password: "SenhaF0rte!2023",
+			name:     "valid password should generate hash without errors",
+			password: "StrongP@ss!2023",
 			setup:    func() application.PasswordUtil { return defaultCostUtils },
 			assertFunc: func(t *testing.T, hash string, err error) {
-				assert.NoError(t, err, "Erro inesperado")
-				assert.NotEmpty(t, hash, "Hash gerado não pode ser vazio")
+				assert.NoError(t, err, "unexpected error")
+				assert.NotEmpty(t, hash, "generated hash must not be empty")
 
-				err = bcrypt.CompareHashAndPassword([]byte(hash), []byte("SenhaF0rte!2023"))
-				assert.NoError(t, err, "Hash não corresponde à senha")
+				err = bcrypt.CompareHashAndPassword([]byte(hash), []byte("StrongP@ss!2023"))
+				assert.NoError(t, err, "hash does not match password")
 			},
 		},
 		{
-			name:     "hashs diferentes para mesma senha",
-			password: "outraSenha123@",
+			name:     "different hashes for same password",
+			password: "anotherPassword123@",
 			setup:    func() application.PasswordUtil { return defaultCostUtils },
 			assertFunc: func(t *testing.T, hash string, err error) {
-				assert.NoError(t, err, "Erro inesperado")
+				assert.NoError(t, err, "unexpected error")
 
-				hash2, err := defaultCostUtils.HashPassword("outraSenha123@")
-				assert.NoError(t, err, "Erro inesperado ao gerar segundo hash")
-				assert.NotEqual(t, hash, hash2, "Hashs idênticos para a mesma senha - salting não está funcionando")
+				hash2, err := defaultCostUtils.HashPassword("anotherPassword123@")
+				assert.NoError(t, err, "unexpected error generating second hash")
+				assert.NotEqual(t, hash, hash2, "identical hashes for same password — salting is not working")
 			},
 		},
 		{
-			name:     "senha vazia deve ser tratada",
+			name:     "empty password should be handled",
 			password: "",
 			setup:    func() application.PasswordUtil { return defaultCostUtils },
 			assertFunc: func(t *testing.T, hash string, err error) {
-				assert.NoError(t, err, "Erro inesperado para senha vazia")
-				assert.GreaterOrEqual(t, utf8.RuneCountInString(hash), 60, "Hash inválido para senha vazia")
+				assert.NoError(t, err, "unexpected error for empty password")
+				assert.GreaterOrEqual(t, utf8.RuneCountInString(hash), 60, "invalid hash for empty password")
 			},
 		},
 		{
-			name:     "senha muito longa",
+			name:     "password too long",
 			password: string(make([]byte, 100)),
 			setup:    func() application.PasswordUtil { return defaultCostUtils },
 			assertFunc: func(t *testing.T, hash string, err error) {
@@ -62,13 +62,13 @@ func TestHashPassword(t *testing.T) {
 			},
 		},
 		{
-			name:     "caracteres especiais e unicode",
+			name:     "special characters and unicode",
 			password: "P@$$w0rd_áéíóú",
 			setup:    func() application.PasswordUtil { return defaultCostUtils },
 			assertFunc: func(t *testing.T, hash string, err error) {
-				assert.NoError(t, err, "Erro inesperado")
+				assert.NoError(t, err, "unexpected error")
 				err = bcrypt.CompareHashAndPassword([]byte(hash), []byte("P@$$w0rd_áéíóú"))
-				assert.NoError(t, err, "Hash não corresponde para caso de caracteres especiais")
+				assert.NoError(t, err, "hash does not match for special characters case")
 			},
 		},
 	}
@@ -81,10 +81,10 @@ func TestHashPassword(t *testing.T) {
 		})
 	}
 
-	t.Run("teste de estresse com múltiplas requisições", func(t *testing.T) {
+	t.Run("stress test with multiple requests", func(t *testing.T) {
 		for i := 0; i < 100; i++ {
-			_, err := defaultCostUtils.HashPassword("senhaTeste")
-			assert.NoError(t, err, "Falha na iteração %d", i)
+			_, err := defaultCostUtils.HashPassword("testPassword")
+			assert.NoError(t, err, "failed on iteration %d", i)
 		}
 	})
 }

--- a/internal/repository/event/create.go
+++ b/internal/repository/event/create.go
@@ -1,13 +1,19 @@
 package event
 
-import "poc-event-source/internal/infrastructure/model"
+import (
+	"poc-event-source/internal/domain"
+	"poc-event-source/internal/infrastructure/model"
+)
 
-func (e *eventRepository) CreateEvent(event *model.EventSource) (*model.EventSource, error) {
-	ev := event
-	err := e.db.Create(ev).Error
-	if err != nil {
+func (e *eventRepository) CreateEvent(event *domain.EventSource) (*domain.EventSource, error) {
+	ev := &model.EventSource{
+		Type:    event.Type,
+		Payload: event.Payload,
+	}
+	if err := e.db.Create(ev).Error; err != nil {
 		return nil, err
 	}
-
-	return ev, err
+	event.ID = ev.ID
+	event.CreatedAt = ev.CreatedAt
+	return event, nil
 }

--- a/internal/repository/event/create.go
+++ b/internal/repository/event/create.go
@@ -7,13 +7,15 @@ import (
 
 func (e *eventRepository) CreateEvent(event *domain.EventSource) (*domain.EventSource, error) {
 	ev := &model.EventSource{
-		Type:    event.Type,
-		Payload: event.Payload,
+		AggregateID: event.AggregateID,
+		Type:        event.Type,
+		Payload:     event.Payload,
 	}
 	if err := e.db.Create(ev).Error; err != nil {
 		return nil, err
 	}
 	event.ID = ev.ID
+	event.Version = ev.Version
 	event.CreatedAt = ev.CreatedAt
 	return event, nil
 }

--- a/internal/repository/event/create.go
+++ b/internal/repository/event/create.go
@@ -1,17 +1,19 @@
 package event
 
 import (
+	"context"
+
 	"poc-event-source/internal/domain"
 	"poc-event-source/internal/infrastructure/model"
 )
 
-func (e *eventRepository) CreateEvent(event *domain.EventSource) (*domain.EventSource, error) {
+func (e *eventRepository) CreateEvent(ctx context.Context, event *domain.EventSource) (*domain.EventSource, error) {
 	ev := &model.EventSource{
 		AggregateID: event.AggregateID,
 		Type:        event.Type,
 		Payload:     event.Payload,
 	}
-	if err := e.db.Create(ev).Error; err != nil {
+	if err := e.db.WithContext(ctx).Create(ev).Error; err != nil {
 		return nil, err
 	}
 	event.ID = ev.ID

--- a/internal/repository/event/create_test.go
+++ b/internal/repository/event/create_test.go
@@ -2,13 +2,15 @@ package event_test
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"poc-event-source/internal/domain"
 	"poc-event-source/internal/infrastructure/model"
 	"poc-event-source/internal/repository/event"
 	"poc-event-source/internal/repository/testutils"
-	"testing"
-	"time"
 )
 
 func TestEventRepository_CreateEvent(t *testing.T) {
@@ -22,13 +24,13 @@ func TestEventRepository_CreateEvent(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		event       *model.EventSource
+		event       *domain.EventSource
 		wantErr     bool
 		errContains string
 	}{
 		{
 			name: "successfully create event with all fields",
-			event: &model.EventSource{
+			event: &domain.EventSource{
 				AggregateID: uuid.NewString(),
 				Type:        "UserCreated",
 				Payload:     []byte(`{"name": "John"}`),
@@ -37,7 +39,7 @@ func TestEventRepository_CreateEvent(t *testing.T) {
 		},
 		{
 			name: "successfully create event with minimum required fields",
-			event: &model.EventSource{
+			event: &domain.EventSource{
 				AggregateID: uuid.NewString(),
 				Type:        "UserUpdated",
 				Payload:     []byte(`{}`),
@@ -46,7 +48,7 @@ func TestEventRepository_CreateEvent(t *testing.T) {
 		},
 		{
 			name: "fail when missing event type",
-			event: &model.EventSource{
+			event: &domain.EventSource{
 				AggregateID: uuid.NewString(),
 				Payload:     []byte(`{"name": "John"}`),
 			},
@@ -55,7 +57,7 @@ func TestEventRepository_CreateEvent(t *testing.T) {
 		},
 		{
 			name: "fail when missing payload",
-			event: &model.EventSource{
+			event: &domain.EventSource{
 				AggregateID: uuid.NewString(),
 				Type:        "UserDeleted",
 			},

--- a/internal/repository/event/create_test.go
+++ b/internal/repository/event/create_test.go
@@ -73,7 +73,7 @@ func TestEventRepository_CreateEvent(t *testing.T) {
 			repo := event.NewEventRepository(tx)
 			defer tx.Rollback()
 
-			createdEvent, err2 := repo.CreateEvent(tt.event)
+			createdEvent, err2 := repo.CreateEvent(ctx, tt.event)
 
 			if tt.wantErr {
 				assert.Error(t, err2)
@@ -102,7 +102,7 @@ func TestEventRepository_CreateEvent(t *testing.T) {
 			assert.WithinDuration(t, createdEvent.CreatedAt, dbEvent.CreatedAt, 5*time.Second)
 
 			if tt.name == "fail with duplicate ID" {
-				_, err := repo.CreateEvent(tt.event)
+				_, err := repo.CreateEvent(ctx, tt.event)
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), "duplicate key")
 			}


### PR DESCRIPTION
## What was done
<!-- Describe the change and why it is necessary -->

## Type of change
- [x] New feature
- [x] Bug fix
- [x] Refactoring
- [x] Tests
- [x] Documentation

## Affected layers
- [x] `domain`
- [x] `application` (interfaces / use cases / DTOs)
- [x] `infrastructure` (NATS / GORM)
- [x] `repository`
- [x] `api` (routes / messaging)

## Checklist
- [x] Follows the constructor pattern (`New*` in `new.go`)
- [x] Interfaces defined in `application/` before implementations
- [x] `context.Context` passed to methods touching DB or broker
- [x] HTTP handler does not write directly to the projection table
- [x] Tests added or updated
- [x] Integration tests use testcontainers (no DB mocks)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User creation endpoint with secure password hashing, validation, and event-driven publishing
  * Handler-based routing and a broker-backed user message subscriber for async processing
  * Public DTOs for user requests and event envelopes; password utilities factory

* **Bug Fixes**
  * Startup tolerates missing .env without failing; broker lifecycle now supports graceful shutdown via OS signals

* **Tests**
  * New unit tests covering user creation, event publishing, repository behavior, and broker subscribe/ack semantics
<!-- end of auto-generated comment: release notes by coderabbit.ai -->